### PR TITLE
commited changes for bugs 63 and 61

### DIFF
--- a/faq/faq-win32.md
+++ b/faq/faq-win32.md
@@ -37,7 +37,7 @@ On ClamAV.net
 
 * Are there 64 bit versions of ClamAV for Windows as well as 32 bit?
 
-Yes.  You can find both versions at [Sourceforge]
+Yes.  You can find both versions at [Clamav/downloads]
 
 [privacy policy]: http://www.cisco.com/web/siteassets/legal/privacy.html
-[Sourceforge]: http://sourceforge.net/projects/clamav/files/clamav/win32/
+[Clamav/downloads]: https://www.clamav.net/downloads#otherversions

--- a/mirrors/MirrorProblems.md
+++ b/mirrors/MirrorProblems.md
@@ -1,6 +1,6 @@
 # Official Mirror FAQ
 
-## Why did freshclam failed to fetch the latest updates?:
+## Why did freshclam fail to fetch the latest updates?:
 
 * Invalid DNS reply. Falling back to HTTP mode or ERROR: Can't query current.cvd.clamav.net  
 


### PR DESCRIPTION
Fixed a spelling mistake where the sentence didn't make sense.
https://git.vrt.sourcefire.com/talosweb/clam-av/issues/63

"Why did freshclam failed to fetch the latest updates?:"

Should probably be:
"Why did freshclam fail to fetch the latest updates?: "



---
Second fix was removing the sourceforge link and replacing it with the download alt windows versions.
https://git.vrt.sourcefire.com/talosweb/clam-av/issues/61