### PR TITLE
FAQ cleanup.  Mostly formatting improvements.

### DIFF
--- a/faq/Installing.md
+++ b/faq/Installing.md
@@ -1,25 +1,25 @@
-# Installing ClamAV #
+# Installing ClamAV
 
-## Installing from source ##
+## Installing from source
 
 * Check [Requirements](#requirements)
 * Uninstall any old version, see [UninstallClamAV] (Note: this isn't essential, but removes sources of problems).
 * wget the source gzip file, see [Which Version].
 * untar the source to an appropriate location. Note that most modern versions of tar will automatically ungzip for you.
 * ensure you have a user clamav and group clamav.
-  * If you're using a different group/user you must specify that using the _--with-user_ and/or _--with-group_ option when you run configure
+  * If you're using a different group/user you must specify that using the `--with-user` and/or `--with-group` option when you run configure
 * Configure the build:
-  * for clamav-milter support _./configure --enable-milter_
-  * to support new features _./configure --enable-experimental_
-  * otherwise _./configure_
-* run _make_
+  * for clamav-milter support `./configure --enable-milter`
+  * to support new features `./configure --enable-experimental`
+  * otherwise `./configure`
+* run `make`
 * if you did not uninstall the previous version, stop any running services.
 * as root, run "make install" to install the binaries
 * it is recommended that you run ldconfig as root after installing
 * restart any relevant services.
 * Run freshclam manually, to ensure your AV definitions are up to date.
 
-### Requirements <a id="requirements" class="anchor">&nbsp;</a> ###
+### Requirements <a id="requirements" class="anchor">&nbsp;</a>
 
 Mandatory:
 
@@ -28,9 +28,9 @@ Mandatory:
 * zlib library
 
 >__Note:__ you must compile with a shared library, use:
->_make clean ; ./configure -s_ __before__ _make_ when building zlib
+>`make clean ; ./configure -s` __before__ `make` when building zlib
 
-### Known Library Compatibility Issues ###
+### Known Library Compatibility Issues
 
 * zlib
   * Certain versions on certain OSes will cause failures loading virus database. 
@@ -39,15 +39,15 @@ Mandatory:
     * AIX 5.3: zlib 1.2.11-1
       * Solution: Try different version, downgrade may be required.
 
-## Installing From Packages ##
+## Installing From Packages
 
 Installing your distribution's packages is the easiest route. It will make also upgrades easier.
 
-### Understand which packages you need ###
+### Understand which packages you need
 
 You don't necessarily need all packages. Please read [ClamOverview] carefully to understand which ones you need.
 
-## Operating System Specific Information ##
+## Operating System Specific Information
 
 * [Debian](#debian)
 * [RHEL/CentOS](#rhel)
@@ -62,73 +62,75 @@ You don't necessarily need all packages. Please read [ClamOverview] carefully to
 * [OpenVMS](#openvms)
 * [OSX](#osx)
 
-### Debian <a id="debian" class="anchor">&nbsp;</a> ###
+### Debian <a id="debian" class="anchor">&nbsp;</a>
 
 
-`` # apt-get update ``
+```bash
+# apt-get update
+# apt-get install clamav
+```
 
-`` # apt-get install clamav ``
-
-### RHEL/CentOS <a id="rhel" class="anchor">&nbsp;</a> ###
+### RHEL/CentOS <a id="rhel" class="anchor">&nbsp;</a>
 
 On CentOS:
 
-
-`` # yum install -y epel-release ``
-
-`` # yum install -y clamav ``
-
+```bash
+# yum install -y epel-release
+# yum install -y clamav
+```
 
 On [Community Enterprise Operating System (CentOS)] the clamav package requires the [Extra Packages for Enterprise Linux (EPEL) repository].
 
 On [RedHat Enterprise Linux (RHEL)] the EPEL release package has to be installed either manually or through RHN.
 
-### Fedora <a id="fedora" class="anchor">&nbsp;</a> ###
+### Fedora <a id="fedora" class="anchor">&nbsp;</a>
 
-```
+```bash
 # yum install -y clamav clamav-update
 ```
 
-### Mandriva <a id="mandriva" class="anchor">&nbsp;</a> ###
+### Mandriva <a id="mandriva" class="anchor">&nbsp;</a>
 
-```
+```bash
 # urpmi clamav clamd
 ```
 
-### Gentoo <a id="gentoo" class="anchor">&nbsp;</a> ###
+### Gentoo <a id="gentoo" class="anchor">&nbsp;</a>
 
-```
+```bash
 # emerge clamav
 ```
 
 See package entry on [Portage].
 
-### openSUSE <a id="opensuse" class="anchor">&nbsp;</a> ###
+### openSUSE <a id="opensuse" class="anchor">&nbsp;</a>
 
-```
+```bash
 # zypper install -y clamav
 ```
 
-### FreeBSD, OpenBSD, NetBSD <a id="bsd" class="anchor">&nbsp;</a> ###
+### FreeBSD, OpenBSD, NetBSD <a id="bsd" class="anchor">&nbsp;</a>
 
 Use the ports Luke.
 
-### Solaris <a id="solaris" class="anchor">&nbsp;</a> ###
+### Solaris <a id="solaris" class="anchor">&nbsp;</a>
 
 
-#### Solaris packages from [OpenCSW] ####
+#### Solaris packages from [OpenCSW]
 
 OpenCSW is a community software project for Solaris 8+ on both Sparc and x86. It packages more than 2000 popular open source titles and they can all easily be installed with dependency handling via _pkgutil_ which is modeled after Debian's _apt-get_.
 
->  # pkgutil -i clamav
+```bash
+# pkgutil -i clamav
+```
 
 More info on [OpenCSW]
 
-### Slackware <a id="slackware" class="anchor">&nbsp;</a> ###
+### Slackware <a id="slackware" class="anchor">&nbsp;</a>
 
 Martijn Dekker provides packages there that provide complete and semi-automatic integration with ClamAV's stock Sendmail package.
 
-### OSX <a id="osx" class="anchor">&nbsp;</a> ###
+### OSX <a id="osx" class="anchor">&nbsp;</a>
 
 Various Installation Guides for OSX can be found on the Internet, two that we have seen are:
 
@@ -136,64 +138,73 @@ Various Installation Guides for OSX can be found on the Internet, two that we ha
 * [Get ClamAV running on Mac OS X (using Homebrew)]
 
 
-#### How to use ####
+#### How to use
 
 Download the package, and as root, install it like so (substituting the appropriate filename):
 
->  # installpkg clamav-0.91.2-i486-1McD.tgz
+```bash
+# installpkg clamav-0.91.2-i486-1McD.tgz
+```
 
 To activate Sendmail integration, after installing the package, copy the ‘/usr/share/sendmail/sendmail-slackware-clamav.cf’ file into ‘/etc/mail/sendmail.cf’:
 
->  # cp /usr/share/sendmail/sendmail-slackware-clamav.cf /etc/mail/sendmail.cf
+```bash
+# cp /usr/share/sendmail/sendmail-slackware-clamav.cf /etc/mail/sendmail.cf
+```
 
 Then start ClamAV and restart Sendmail:
 
->  # /etc/rc.d/rc.clamav start
+```bash
+# /etc/rc.d/rc.clamav start
+# /etc/rc.d/rc.sendmail restart
+```
 
->  # /etc/rc.d/rc.sendmail restart
-
-#### Building your own ####
+#### Building Your Own Package
 
 You may wish to build your own package if I haven't uploaded one with the most recent version yet, if you use a pre-11.0 Slackware version (at the time of this writing, I build on 11.0, 12.0 and 12.1, and my binaries may not work on earlier versions), if you don't trust third-party binaries, or simply because you're a complete geek ;-) . You can download my easy-to-use Slackbuild script, from which the fully-integrated ClamAV packages at Linuxpackages.net are generated.
 
 This script can be used to build a ClamAV package for Slackware 10.0 or higher with Sendmail installed (as Sendmail milter support was introduced as of 10.0). To choose a version of ClamAV to build, you can ‘cd’ to the script's directory and invoke the script like so:
 
-> $ VERSION=1.23.4 ./clamav.SlackBuild
+```bash
+$ VERSION=1.23.4 ./clamav.SlackBuild
+```
 
 …substituting, of course, the appropriate ClamAV version for ‘1.23.4’. Note: there is no need to be root to use this build script; it will ask for your root password after building the binaries and just before creating the package (and if you have fakeroot installed, even that isn't necessary).
 
-### Windows <a id="windows" class="anchor">&nbsp;</a> ###
+### Windows <a id="windows" class="anchor">&nbsp;</a>
 
-#### First update Windows ####
+#### First update Windows
 
 * Microsoft Update
 
-#### Available packages ####
+#### Available Packages
 
-clamAV.msi - base package for clamav, an anti-virus utility for Windows
+ClamAV.msi - base package for clamav, an anti-virus utility for Windows
 
-#### How to install ####
+#### How to Install
 
 * simple mode: doubleclick the MSI installer package
 * command line (displays only a confirmation dialog at the end): msiexec /i clamAV.msi /qr
 
-#### Requirements ####
+#### Requirements
 
 Microsoft .net version 2.0 is required starting with ClamAV 0.92.1
 
-### OpenVMS <a id="openvms" class="anchor">&nbsp;</a> ###
+### OpenVMS <a id="openvms" class="anchor">&nbsp;</a>
 
 The ClamAV [for OpenVMS] port is maintained by Alexey Chupahin, Mibok Ltd
 
-Please visit Clamav [OpenVMS project site]
+Please visit ClamAV [OpenVMS project site]
 
 First, you should download latest clamav sources and bzip2 library (if you need bz2 archives support) from the site above. Install process is very similar to one in unix:
 
->@configure
->
->@build
->
->@clamav$startup
+```
+@configure
+
+@build
+
+@clamav$startup
+```
 
 This process provides for you:
 

--- a/faq/ReportABug.md
+++ b/faq/ReportABug.md
@@ -1,53 +1,126 @@
-#How to Report A Bug#
+# How to Report A Bug
 
-If you find a bug in ClamAV, please check it against the latest git code. Read the instructions below, then visit our <a href="https://bugzilla.clamav.net/" target="_blank">bug tracker</a> to submit your bug report. Please do not submit bugs for third party software.
+If you find a bug in ClamAV, please check it against the latest git code. Read the instructions below, then visit our [bug tracker](https://bugzilla.clamav.net/) to submit your bug report. Please do not submit bugs for third party software.
 
-##Required Information##
+## Required Information
+
 Please be sure to include all of the following information so that we can effectively address your bug:
 
-+ __E-mail address :__  a working email address so the developers can get in touch with you to obtain additional info and notify you when the problem is fixed.
-+ __ClamAV version and settings :__ the output from: <code>clamconf -n</code>
-+ __3rd party signatures :__ whether you are using any unofficial signature databases, that is anything other than main.cvd/cld and daily.cvd/cld
-+ __System details :__ full specs of your system: i.e. output from: <code>uname -mrsp</code>
-+ __Library versions :__ your libc and possibly zlib versions
-+ __How to reproduce the problem :__ if the issue is reproducible only when scanning a specific file, attach it to the message. Don’t forget to encrypt it or you may cause damage to the mail servers between you and us! E.g.: <code>zip -P virus -e file.zip file.ext</code>.<br>The content of the file will be kept confidential.
++ __E-mail address:__
 
-####Large Files###
+  a working email address so the developers can get in touch with you to obtain additional info and notify you when the problem is fixed.
+
++ __ClamAV version and settings:__
+
+  the output from: `clamconf -n`
+
++ __3rd party signatures:__
+
+  whether you are using any unofficial signature databases, that is anything other than main.cvd/cld and daily.cvd/cld
+
++ __System details:__
+
+  full specs of your system: i.e. output from: `uname -mrsp`
+
++ __Library versions:__
+
+  your libc and possibly zlib versions
+
++ __How to reproduce the problem:__
+
+  if the issue is reproducible only when scanning a specific file, attach it to the message.  _Don’t forget to encrypt it or you may cause damage to the mail servers between you and us!_ 
+
+  E.g.: `zip -P virus -e file.zip file.ext`.
+
+  The content of the file will be kept confidential.
+
+#### Large Files
+
 If the file is too big to mail it, you can upload it to a password protected website and send us the URL and the credentials to access it.
 
-##Backtrace Instructions##
-Backtrace of clamscan: if possible, please send us the backtrace obtained from gdb, the GNU Project Debugger.  
+## Backtrace Instructions
+
+Backtrace of clamscan: If possible, please send us the backtrace obtained from gdb, the GNU Project Debugger.  
 Here are step by step instructions which will guide you through the process.
-__Assuming you get something like:__	<code>$ clamscan --some-options some_file</code> <code>Segmentation fault</code>
+__Assuming you get something like:__
 
-1. Have the kernel write a core dump. <br> For bourne-like shells (e.g. bash): <br>	<code>$ ulimit -c unlimited</code><br>For C-like shells (e.g. tcsh): <br><code>limit coredumpsize unlimited</code>
-1. Now you should see the core dumped message:<br><code>$ clamscan --some-options some_file</code><br><code>Segmentation fault (core dumped)</code><br>Looking at your current working directory should reveal a file named core.
-1. Load the core file into gdb:<br><code>$ gdb -core=core --args clamscan --some-options some_file</code><br><code>(gdb)</code>. <br>You should now see the gdb prompt.
-1. Just use the <code>bt</code> command at the prompt to make gdb print a full backtrace.<br>Copy and paste it into the bug report. You can use the q command to leave gdb.
+```bash
+$ clamscan --some-options some_file
+Segmentation fault
+```
 
-##Obtain a Backtrace of clamd:##
-
-Use ps to get the PID of clamd (first number from the left):  
-<code>$ ps -aux (or ps -elf on SysV)</code>  
-clamav 24897 0.0 1.9 38032 10068 ? S Jan13 0:00 clamd  
+1. Have the kernel write a core dump. 
+  For bourne-like shells (e.g. bash): 
   
-Attach gdb to the running process:  
-<code>$ gdb /usr/sbin/clamd 24897</code>  
+  ```
+  $ ulimit -c unlimited
+  ```
+  
+  For C-like shells (e.g. tcsh): 
+  
+  ```tsch
+  limit coredumpsize unlimited
+  ```
+
+2. Now you should see the core dumped message:
+  ```bash
+  $ clamscan --some-options some_file
+  Segmentation fault (core dumped)
+  
+  Looking at your current working directory should reveal a file named core.
+
+3. Load the core file into gdb:
+
+  ```bash
+  $ gdb -core=core --args clamscan --some-options some_file
+  (gdb)
+  ```
+  
+  You should now see the gdb prompt.
+  
+4. Just use the `bt` command at the prompt to make gdb print a full backtrace.  Copy and paste it into the bug report. You can use the `q` command to leave gdb.
+
+## Obtain a Backtrace of clamd
+
+Use `ps` to get the PID of clamd (first number from the left):
+
+```bash
+$ ps -aux (or ps -elf on SysV)
+clamav 24897 0.0 1.9 38032 10068 ? S Jan13 0:00 clamd  
+```
+  
+Attach gdb to the running process:
+
+```bash
+$ gdb /usr/sbin/clamd 24897
+```
+
 Replace 24897 with the pid of clamd and adjust the path of clamd.
 
 You should now get the gdb prompt, as:  
-<code>(gdb)</code>  
-If you want clamd to continue running (i.e. until a segmentation fault occurs), issue the  
-<code>continue gdb</code>  
-command, and __wait for an error__, at which point gdb will return to its prompt.  
 
-####Commands####
+```
+(gdb)
+```
 
-+ <code>bt</code>  will give a backtrace for the current thread.
-+ <code>info threads</code> 	will tell you how many threads there are.  
-+ <code>thread n</code>  will change to the specified thread, after which you can use the bt command again to get it’s backtrace.  
+If you want clamd to continue running (i.e. until a segmentation fault occurs), issue the `continue gdb` command, and __wait for an error__, at which point gdb will return to its prompt.  
 
-So, you basically want to use <code>Info threads</code> to get the number of threads and their id numbers; and for each thread do <code>thread id_number</code>; then <code>bt</code>. Exit from gdb with the <code>quit</code> command. Reply <code>y</code> to the question about the program still running.
+#### Commands
 
-####Strace####
-Optionally, if you think it can help, the output from strace can be included in the report (not covered here).
++ `bt`
+
+  will give a backtrace for the current thread.
+
++ `info threads`
+
+  will tell you how many threads there are.
+
++ `thread n`
+
+  will change to the specified thread, after which you can use the bt command again to get it’s backtrace.  
+
+So, you basically want to use `info threads` to get the number of threads and their id numbers; and for each thread do `thread id_number`; then `bt`. Exit from gdb with the `quit` command. Reply `y` to the question about the program still running.
+
+#### Strace
+
+Optionally, if you think it can help, the output from `strace` can be included in the report (not covered here).

--- a/faq/faq-cctts.md
+++ b/faq/faq-cctts.md
@@ -1,64 +1,64 @@
-# ClamAV Community Threat Tracking System #
+# ClamAV Community Threat Tracking System
 
-## Official FAQ ##
+## Official FAQ
 
-* What is the CCTTS?
+### What is the CCTTS?
 
->The ClamAV Community Threat Tracking System sends summary data to our server about the malware detected on your system. Freshclam usually sends the data when you update your signatures. You can also use freshclam’s --submit-stats option to submit statistics without updating the signature database.
+The ClamAV Community Threat Tracking System sends summary data to our server about the malware detected on your system. Freshclam usually sends the data when you update your signatures. You can also use freshclam’s --submit-stats option to submit statistics without updating the signature database.
 
-* How do you use the data you collect?
+### How do you use the data you collect?
 
->The ClamAV team and Sourcefire VRT use the data to determine the most active malware in real-time and to monitor activity based on historical trends. We will make all of our findings public.
+The ClamAV team and Sourcefire VRT use the data to determine the most active malware in real-time and to monitor activity based on historical trends. We will make all of our findings public.
 
-* Can I see the results?
+### Can I see the results?
 
->Yes! The amount of analysis that we can publish depends on the amount of data that we receive. We need enough data to have confidence in any conclusions drawn; so as more users submit more data we can publish more analyses.
+Yes! The amount of analysis that we can publish depends on the amount of data that we receive. We need enough data to have confidence in any conclusions drawn; so as more users submit more data we can publish more analyses.
 
 
-* How do I enable Anonymous Statistics?
+### How do I enable Anonymous Statistics?
 
->Look in your freshclam.conf (usually located in /usr/local/etc/freshclam.conf) for the entry “SubmitDetectionStats” and ensure it is enabled and points to your clamd.conf, for example “SubmitDetectionStats /usr/local/etc/clamd.conf”. When you enable SubmitDetectionStats freshclam will fetch the latest statistics from clamd and submit them to our server.
+Look in your freshclam.conf (usually located in /usr/local/etc/freshclam.conf) for the entry “SubmitDetectionStats” and ensure it is enabled and points to your clamd.conf, for example “SubmitDetectionStats /usr/local/etc/clamd.conf”. When you enable SubmitDetectionStats freshclam will fetch the latest statistics from clamd and submit them to our server.
 
-* How can I see statistics regarding the malware detected by my own ClamAV installation?
+### How can I see statistics regarding the malware detected by my own ClamAV installation?
 
->Get a HostID (see following FAQs) for each of your ClamAV installations and add the directive "DetectionStatsHostID XXXX" (where XXXX is your HostID) to your freshclam.conf. You will be able to view the data submitted by your ClamAV installation anytime by logging on [http://www.stats.clamav.net](http://www.stats.clamav.net).
+Get a HostID (see following FAQs) for each of your ClamAV installations and add the directive "DetectionStatsHostID XXXX" (where XXXX is your HostID) to your freshclam.conf. You will be able to view the data submitted by your ClamAV installation anytime by logging on [http://www.stats.clamav.net](http://www.stats.clamav.net).
 
-* What is a HostID?
+### What is a HostID?
 
->A HostID is a unique identifier which helps us tracking data submissions from individual ClamAV installations. 
+A HostID is a unique identifier which helps us tracking data submissions from individual ClamAV installations. 
 
-* How do I get a HostID?
+### How do I get a HostID?
 
->You can get your own HostID by logging on [http://www.stats.clamav.net](http://www.stats.clamav.net) and clicking on "Add new host"
+You can get your own HostID by logging on [http://www.stats.clamav.net](http://www.stats.clamav.net) and clicking on "Add new host"
 
-* How does Freshclam send data?
+### How does Freshclam send data?
 
->Freshclam sends the data to stats.clamav.net using HTTP (POST) port 80.
+Freshclam sends the data to stats.clamav.net using HTTP (POST) port 80.
 
-* What data does freshclam actually submit?
+### What data does freshclam actually submit?
 
->File name, malware name, and time of detection for each malware that is detected.
+File name, malware name, and time of detection for each malware that is detected.
 
-* Does Freshclam send private data?
+### Does Freshclam send private data?
 
->None, other than the public IP address that freshclam is using to contact our server.
+None, other than the public IP address that freshclam is using to contact our server.
 
-* Do you send any of my data to third parties?
+### Do you send any of my data to third parties?
 
->No. We only make our trend analyses available to third parties. We do not charge for these analyses, we provide them as a service to the Open Source Community.
+No. We only make our trend analyses available to third parties. We do not charge for these analyses, we provide them as a service to the Open Source Community.
 
-* Why should I contribute data?
+### Why should I contribute data?
 
->The more data that we receive, the better the quality of the analyses since the analyses are based on more statistically significant data sets. You will be contributing back to the Open Source Community.
+The more data that we receive, the better the quality of the analyses since the analyses are based on more statistically significant data sets. You will be contributing back to the Open Source Community.
 
-* Do other AV vendors do this?
+### Do other AV vendors do this?
 
->Yes. It is common practice within the security industry to gather and use such data.
+Yes. It is common practice within the security industry to gather and use such data.
 
-* What is the size of transmitted data?
+### What is the size of transmitted data?
 
->To optimize the submission process and to reduce the load on our servers, freshclam submits the data in sets of 10 records, up to 50 in one session. Thus if you have 45 new records, then it will submit 40; if you have 78 then it will submit the latest 50 entries; and if you have only 9 records freshclam won't submit any.
+To optimize the submission process and to reduce the load on our servers, freshclam submits the data in sets of 10 records, up to 50 in one session. Thus if you have 45 new records, then it will submit 40; if you have 78 then it will submit the latest 50 entries; and if you have only 9 records freshclam won't submit any.
 
-* I am not running clamd; can I still use this feature?
+### I am not running clamd; can I still use this feature?
 
->Clamd’s logfile is the data source (see the LogFile setting in clamd.conf). In principle, any program that writes correct records to that file will generate data usable by freshclam, but most users will need to be using clamd to make use of this feature. For example, freshclam will not submit malware detected by clamscan because clamscan does not write to the logfile.
+Clamd’s logfile is the data source (see the LogFile setting in clamd.conf). In principle, any program that writes correct records to that file will generate data usable by freshclam, but most users will need to be using clamd to make use of this feature. For example, freshclam will not submit malware detected by clamscan because clamscan does not write to the logfile.

--- a/faq/faq-cvd.md
+++ b/faq/faq-cvd.md
@@ -1,6 +1,6 @@
-# ClamAV Virus Database FAQ #
+# ClamAV Virus Database FAQ
 
-* What does _WARNING: DNS record is older than 3 hours_ mean?
+### What does _WARNING: DNS record is older than 3 hours_ mean?
 
 freshclam attempts to detect potential problems with DNS caches and  switches to the old mode if something looks suspicious. If this message appears seldomly, you can safely ignore it. If you get the error everytime you run freshclam, check your system clock. If it is set correctly, check your dns settings.  If those didn't help, try putting this at the top of your cronjob:  
 
@@ -8,78 +8,103 @@ freshclam attempts to detect potential problems with DNS caches and  switches to
 
 The 4th field of the first line should be less than 3 &lowast; 3600 behind the output of the second line. If not, you have a caching DNS server somewhere  misbehaving.
 
-* How often is the virus database updated?
+### How often is the virus database updated?
 
 The virus database is usually updated many times per week. Sign up for our [VirusDB mailing list] to see our response times to new threats. The virusdb team tries to keep up with the latest threats in the wild.  You can contribute to make the virusdb updating process  more efficient by submitting samples of viruses via our "[Contact]" page on ClamAV.net.
 
-* How many times per hour shall I run freshclam?
+### How many times per hour shall I run freshclam?
 
-You can check for database update as often as 4 times per hour provided that you have the following options in freshclam.conf: __DNSDatabaseInfo current.cvd.clamav.net__ __DatabaseMirror db.XY.clamav.net__ __DatabaseMirror database.clamav.net__   
+You can check for database update as often as 4 times per hour provided that you have the following options in freshclam.conf: 
+
+```
+DNSDatabaseInfo current.cvd.clamav.net
+DatabaseMirror db.XY.clamav.net
+DatabaseMirror database.clamav.net
+```  
+
 Replace XY with your [country code].  If you don't have that option, then you must stick with 1 check per hour.
 
-* The last CVD update crashed my ClamAV installation. Why?
+### The last CVD update crashed my ClamAV installation. Why?
 
 Before publishing a CVD update, we verify that it can be correctly loaded by the last two stable release series of ClamAV.
 
-* The last CVD update detects a lot of false positives on my system. Why?
+### The last CVD update detects a lot of false positives on my system. Why?
 
 Before publishing a CVD update, we test it for false positives using the latest stable release of ClamAV. If you want to avoid problems with false positives, you must run the latest stable version of ClamAV.
 
-* I tried to submit a sample through the web interface, but it said the sample is already recognized by ClamAV. My clamscan tells me it's not. I have already updated my database and ClamAV engine, what's wrong with my setup?
+### I tried to submit a sample through the web interface, but it said the sample is already recognized by ClamAV. My clamscan tells me it's not. I have already updated my database and ClamAV engine, what's wrong with my setup?
 
 Please run clamscan with the `--detect-broken` option. Also  check that freshclam and clamscan are using the same path for storing/reading the database.
 
-* I found an infected file in my HD/floppy/mailbox, but ClamAV doesn't recognize it yet. Can you help me? 
+### I found an infected file in my HD/floppy/mailbox, but ClamAV doesn't recognize it yet. Can you help me? 
 
 Our virus database is kept up to date with the help of the community. Whenever you find a new virus which is not detected by ClamAV you should  "complete this form":submit. The virusdb team will review your submission and update the database if necessary. Before submitting a new sample: - check that the value of DatabaseDirectory, in both clamd.conf and freshclam.conf, is the same - update your database by running freshclam
 
-* How do I keep my virus database up to date?
+### How do I keep my virus database up to date?
 
 ClamAV comes with _freshclam_, a tool which periodically checks for new database releases and keeps your database up to date.
 
-* I get this error when running freshclam: _Invalid DNS reply. Falling back to HTTP mode_ or _ERROR: Can't query current.cvd.clamav.net_ . What does it mean?
+### I get this error when running freshclam: _Invalid DNS reply. Falling back to HTTP mode_ or _ERROR: Can't query current.cvd.clamav.net_ . What does it mean?
 
 There is a problem with your DNS server. Please check the entries in /etc/resolv.conf and verify that you can resolve the TXT record manually: `$ host -t txt current.cvd.clamav.net`  
 If you can't, it means your network is broken. You'll be still able to download the updates, but you'll waste a lot of bandwidth checking for updates.
 
-* I get this error when running freshclam: _ERROR: Connection with ??? failed_ . What shall I do?
+### I get this error when running freshclam: _ERROR: Connection with ??? failed_ . What shall I do?
 
-Either your dns servers are not working or you are blocking port 53/tcp. You should manually check that you can resolve hostnames with: `$ host database.clamav.net`.  
+Either your dns servers are not working or you are blocking port 53/tcp. You should manually check that you can resolve hostnames with: 
+
+```bash
+$ host database.clamav.net
+```
  
 If it doesn't work, check your dns settings in /etc/resolv.conf. If it works, check that you can receive dns answers longer than 512 bytes, e.g. check that your firewall is not blocking packets which originate from port 53/tcp.
 
-An easy way to find it out is:  `$ dig @ns1.clamav.net db.us.big.clamav.net`
+An easy way to find it out is:
 
-* How do I know if my IP address has been blacklisted?
+```bash
+$ dig @ns1.clamav.net db.us.big.clamav.net
+```
+
+### How do I know if my IP address has been blacklisted?
 
 Try to download daily.cvd with lynx or wget from the same machine that is running freshclam. Future versions of freshclam will provide a better way to deal with this.
 
-* What is the mirrors.dat file?
+### What is the mirrors.dat file?
 
 mirrors.dat is used by freshclam to keep track of broken mirrors. It avoids the unnecessary delays caused by trying to download a CVD update from a mirror which failed multiple times during the last 24 hours.
 
-* I'm running ClamAV on a lot of clients on my local network. Can I serve the cvd files from a local server so that each client doesn't have to download them from your servers?
+### I'm running ClamAV on a lot of clients on my local network. Can I serve the cvd files from a local server so that each client doesn't have to download them from your servers?
 
-Sure, you can find more details on our [Mirror page]. 
+Sure, you can find more details on our [Mirror page].
 
-If you want to take advantage of incremental updates, install a proxy server and then configure your freshclam clients to use it (watch for the HTTPProxyServer parameter in man freshclam.conf). 
+1. If you want to take advantage of incremental updates, install a proxy server and then configure your freshclam clients to use it (watch for the HTTPProxyServer parameter in man freshclam.conf). 
 
-The second possible solution is to configure a local webserver on one of your machines (say machine1.mylan) and let freshclam download the \*.cvd files from http://database.clamav.net to the webserver's DocumentRoot. Add this line to freshclam.conf on machine1.mylan: `ScriptedUpdates off`.   
-First the database will be downloaded to the local webserver and then the other clients on the network will update their copy of the database from it.
+2. The second possible solution is to:
 
- For this to work you have to change freshclam.conf on your clients so that it reads:  
-`DatabaseMirror machine1.mylan`  
-`ScriptedUpdates off`
+  * Configure a local webserver on one of your machines (say machine1.mylan) 
+  
+  * Let freshclam download the \*.cvd files from http://database.clamav.net to the webserver's DocumentRoot. 
 
-* I can't wait for you to update the database! I need to use the new signature NOW!
+  * Finally, change freshclam.conf on your clients so that it includes:
+    
+    ```
+    DatabaseMirror machine1.mylan
+    ScriptedUpdates off
+    ```
+    
+    First the database will be downloaded to the local webserver and then the other clients on the network will update their copy of the database from it. 
+    
+    _Important_:  For this to work, you have to add `ScriptedUpdates off` on all of your machines!
+
+### I can't wait for you to update the database! I need to use the new signature NOW!
 
 No problem, save your own signatures in a text file with the appropriate extension. Put it in the same dir where the .cvd files are located. ClamAV will load it after the official .cvd files. You need not to sign the .db file .
 
-* Can I download the virusdb manually?
+### Can I download the virusdb manually?
 
 Yes, the virusdb can be downloaded from the _Latest releases_ section on our home page.
 
-* I can't resolve current.cvd.clamav.net! Is there a problem with your/my DNS servers?
+### I can't resolve current.cvd.clamav.net! Is there a problem with your/my DNS servers?
 
 current.cvd.clamav.net has got only a TXT record, not a type A record! Try this command:   
 `$ host -t txt current.cvd.clamav.net`

--- a/faq/faq-eol.md
+++ b/faq/faq-eol.md
@@ -1,4 +1,4 @@
-# End of Life Policy (EOL) #
+# End of Life Policy (EOL)
 
 The naming convention for ClamAV releases uses three numbers (X.Y.Z) where the first two (X.Y) identify a major release and the last one (Z) a minor release.
 

--- a/faq/faq-ignore.md
+++ b/faq/faq-ignore.md
@@ -1,14 +1,20 @@
 # How do I ignore/whitelist a ClamAV signature?
 
-* Creating a ignore/whitelist file
->Change Directory into the location where your ClamAV databases are stored.  Create a file called "whitelist.ign2", for example, like this:
+### Creating a ignore/whitelist file
 
-><code>touch whitelist.ign2</code>
+Change Directory into the location where your ClamAV databases are stored.  Create a file called "whitelist.ign2", for example, like this:
 
-* Ignore individual signatures
-> Place the signatures you'd like to ignore, each in it's own line, within the file whitelist.ign2.  
-> For example:
+```bash
+touch whitelist.ign2
+```
 
-><code>Signature.Ignore-1</code>
->
-><code>Signature.Ignore-2</code>
+### Ignore individual signatures
+
+Place the signatures you'd like to ignore, each in it's own line, within the file whitelist.ign2.  
+
+For example:
+
+```
+Signature.Ignore-1
+Signature.Ignore-2
+```

--- a/faq/faq-misc.md
+++ b/faq/faq-misc.md
@@ -1,57 +1,61 @@
 # Miscellaneous FAQ #
 
-* Can phishing be considered one kind of spam? ClamAV should not detect it as some kind of malware.
+### Can phishing be considered one kind of spam? ClamAV should not detect it as some kind of malware.
 
->Starting from release 0.90, ClamAV allows you to choose whether to detect phish as some kind of malware or not. This should put an end to the endless threads on our mailing lists. So long, and  thanks for all the phish.
+Starting from release 0.90, ClamAV allows you to choose whether to detect phish as some kind of malware or not. This should put an end to the endless threads on our mailing lists. So long, and  thanks for all the phish.
 
-* Why is my legitimate HTML newsletter/email detected by ClamAV as Phishing.Heuristics.Email.SpoofedDomain?
+### Why is my legitimate HTML newsletter/email detected by ClamAV as Phishing.Heuristics.Email.SpoofedDomain?
 
->If it contains links in the form of href="http://yourdomain.example.tld"&gt; otherdomain.tld, where ProtectedDomain doesn't belong to you and is listed in ClamAV database (like amazon.com, ebay.com, ...) then ClamAV detects it as a phishing attempt.
+If it contains links in the form of href="http://yourdomain.example.tld"&gt; otherdomain.tld, where ProtectedDomain doesn't belong to you and is listed in ClamAV database (like amazon.com, ebay.com, ...) then ClamAV detects it as a phishing attempt.
 
-* My legitimate emails from yourdomain.tld are detected as Phishing.Heuristics.Email.SpoofedDomain
+### My legitimate emails from yourdomain.tld are detected as Phishing.Heuristics.Email.SpoofedDomain
 
->Please [submit a sample](http://www.clamav.net/report/report-malware.html), marking it as a false positive, phishing. If it's really a false positive, we will add a whitelist entry for it.
+Please [submit a sample](http://www.clamav.net/report/report-malware.html), marking it as a false positive, phishing. If it's really a false positive, we will add a whitelist entry for it.
 
-* Can I convert the new database format to the old one? 
+### Can I convert the new database format to the old one? 
 
->Yes, install a recent version of sigtool and run: <code>sigtool --unpack-current daily.cvd; sigtool --unpack-current main.cvd</code>
+Yes, install a recent version of sigtool and run:
 
-* How do I read inside the CVD files?
+```bash
+sigtool --unpack-current daily.cvd; sigtool --unpack-current main.cvd
+```
 
->See previous FAQ.
+### How do I read inside the CVD files?
 
-* I'm using ClamAV in a production environment and a brand new virus is not being recognized by ClamAV. How long do I have to wait before ClamAV can start filtering the virus?
+See previous FAQ.
 
->No time at all! Find a signature for that virus and modify your  virus database accordingly (see signatures.pdf in the _doc/_ dir). Remember to "submit":submit the sample to the virusdb team. 
+### I'm using ClamAV in a production environment and a brand new virus is not being recognized by ClamAV. How long do I have to wait before ClamAV can start filtering the virus?
 
-* Why is ClamAV calling the XXX virus with another name?
+No time at all! Find a signature for that virus and modify your  virus database accordingly (see signatures.pdf in the _doc/_ dir). Remember to "submit":submit the sample to the virusdb team. 
 
->This usually happens when we add a signature _before_ other  AV vendors. No well-known name is available at that moment so we have to invent one. Renaming the virus after a few days would just confuse people more, so we usually keep on using  our name for that virus. The only exception is when a new name is established soon after the signature addition. 
+### Why is ClamAV calling the XXX virus with another name?
 
-* I get many false positives of Oversized.zip
+This usually happens when we add a signature _before_ other  AV vendors. No well-known name is available at that moment so we have to invent one. Renaming the virus after a few days would just confuse people more, so we usually keep on using  our name for that virus. The only exception is when a new name is established soon after the signature addition. 
 
->Whenever a file exceeds ArchiveMaxCompressionRatio (see clamd.conf man page), it's considered a logic bomb and marked as Oversized.zip . Try increasing your ArchiveMaxCompressionRatio setting.
+### I get many false positives of Oversized.zip
 
-* What is PUA? I get a lot of false positives named PUA.
+Whenever a file exceeds ArchiveMaxCompressionRatio (see clamd.conf man page), it's considered a logic bomb and marked as Oversized.zip . Try increasing your ArchiveMaxCompressionRatio setting.
 
->With the release of ClamAV 0.91.2 we introduce the option to scan for Potentially Unwanted Applications.   
->
->The PUA database contains detection for applications that are not malicious by itself but can be used in a malicious or unwanted context. As an example: A tool to retrieve passwords from a system can be useful as long as the person who uses it, is authorized to do so. However, the same tool can be used to steal passwords from a system. To make use of the PUA database you can use the __--detect-pua switch__ for clamscan or enable it in the config file for clamd (add: DetectPUA yes). 
->
->At this point we DO NOT recommend using it in production environments, because the detection may be too aggressive and lead to false positives. In one of the next releases we will provide additional features for fine-tuning allowing better adjustments to different setups. NOTE: A detection as PUA does NOT tell if an application is good or bad. All it says is, that a file MAY BE unwanted or MAYBE could compromise your system security and it MAY BE a good idea to check it twice.
+### What is PUA? I get a lot of false positives named PUA.
 
-* Can ClamAV disinfect files?
+With the release of ClamAV 0.91.2 we introduce the option to scan for Potentially Unwanted Applications.   
 
->No, it can't. We will add support for disinfecting OLE2 files in one of the next stable releases. There are no plans for disinfecting other types of files. There are many reasons for it: cleaning viruses from files is virtually pointless these days. It is very seldom that there is anything useful left after cleaning, and even if there is, would you trust it?
+The PUA database contains detection for applications that are not malicious by itself but can be used in a malicious or unwanted context. As an example: A tool to retrieve passwords from a system can be useful as long as the person who uses it, is authorized to do so. However, the same tool can be used to steal passwords from a system. To make use of the PUA database you can use the __--detect-pua switch__ for clamscan or enable it in the config file for clamd (add: DetectPUA yes). 
 
-* When using clamscan, is there a way to know which message within an mbox is infected?
+At this point we DO NOT recommend using it in production environments, because the detection may be too aggressive and lead to false positives. In one of the next releases we will provide additional features for fine-tuning allowing better adjustments to different setups. NOTE: A detection as PUA does NOT tell if an application is good or bad. All it says is, that a file MAY BE unwanted or MAYBE could compromise your system security and it MAY BE a good idea to check it twice.
 
->There are two solutions: Run <code>clamscan --debug</code>, look for _Deal with email number xxx_ Alternatively you can convert the mbox to Maildir  format, run clamscan on it and then convert it back to mbox format. There are many tools available which can convert to and from Maildir format: formail, mbox2maildir and maildir2mbox
+### Can ClamAV disinfect files?
 
-* What platforms does it support ?
+No, it can't. We will add support for disinfecting OLE2 files in one of the next stable releases. There are no plans for disinfecting other types of files. There are many reasons for it: cleaning viruses from files is virtually pointless these days. It is very seldom that there is anything useful left after cleaning, and even if there is, would you trust it?
 
->Clam AntiVirus works with Linux&reg;, Solaris, FreeBSD, OpenBSD, NetBSD, AIX, Mac OS X, Cygwin B20 on  multiple architectures such as Intel, Alpha, Sparc, Cobalt MIPS boxes, PowerPC, RISC 6000. 
+### When using clamscan, is there a way to know which message within an mbox is infected?
 
-* Where can I find more information about ClamAV?
+There are two solutions: Run `clamscan --debug`, look for _Deal with email number xxx_ Alternatively you can convert the mbox to Maildir  format, run clamscan on it and then convert it back to mbox format. There are many tools available which can convert to and from Maildir format: formail, mbox2maildir and maildir2mbox
 
->Please read the complete documentation in pdf/ps format. You will find it inside the package or in the "documentation":doc section of this website. You can also try searching the "mailing list archives":ml.  If you can't find the answer, you can ask for support on the clamav-users mailing-list, but  _please_ before doing it, search the archives! Also, make sure that you don't send HTML messages and that you don't top post: these violate the netiquette and lessen your chances of being answered.
+### What platforms does it support ?
+
+Clam AntiVirus works with Linux&reg;, Solaris, FreeBSD, OpenBSD, NetBSD, AIX, Mac OS X, Cygwin B20 on  multiple architectures such as Intel, Alpha, Sparc, Cobalt MIPS boxes, PowerPC, RISC 6000. 
+
+### Where can I find more information about ClamAV?
+
+Please read the complete documentation in pdf/ps format. You will find it inside the package or in the "documentation":doc section of this website. You can also try searching the "mailing list archives":ml.  If you can't find the answer, you can ask for support on the clamav-users mailing-list, but  _please_ before doing it, search the archives! Also, make sure that you don't send HTML messages and that you don't top post: these violate the netiquette and lessen your chances of being answered.

--- a/faq/faq-ml.md
+++ b/faq/faq-ml.md
@@ -1,30 +1,30 @@
 # Mailing Lists FAQ#
 
 
-* Where can I ask questions about using ClamAV?
+### Where can I ask questions about using ClamAV?
 
->Subscribe to our [clamav-users](http://lists.clamav.net/cgi-bin/mailman/listinfo/clamav-users) mailing-list.
+Subscribe to our [clamav-users](http://lists.clamav.net/cgi-bin/mailman/listinfo/clamav-users) mailing-list.
 
-* I want to take part to the development of ClamAV. Where can I get more info?
+### I want to take part to the development of ClamAV. Where can I get more info?
 
->Subscribe to the [clamav-devel](http://lists.clamav.net/cgi-bin/mailman/listinfo/clamav-devel) mailing-list.
+Subscribe to the [clamav-devel](http://lists.clamav.net/cgi-bin/mailman/listinfo/clamav-devel) mailing-list.
 
-* The mailing-lists generate too many messages per day. I can't handle them. What shall I do?
+### The mailing-lists generate too many messages per day. I can't handle them. What shall I do?
 
->There are two possible solutions: 	- Go to the [mailing-list](http://lists.clamav.net/cgi-bin/mailman/listinfo) mailman interface, click on __Unsubscribe or edit options__, and turn _digest mode_ on 	- access the mailing-lists using a "news reader"
+There are two possible solutions: 	- Go to the [mailing-list](http://lists.clamav.net/cgi-bin/mailman/listinfo) mailman interface, click on __Unsubscribe or edit options__, and turn _digest mode_ on 	- access the mailing-lists using a "news reader"
 
-* I sent a message to one of ClamAV's mailing-lists, but the mail was rejected/held for approval. Why?
+### I sent a message to one of ClamAV's mailing-lists, but the mail was rejected/held for approval. Why?
 
->Only subscribers are allowed to post to the mailing-list. This is done to avoid spammers.  
+Only subscribers are allowed to post to the mailing-list. This is done to avoid spammers.  
 
-* I read the mailing-list from the Gmane news gateway. Can I post to the mailing-list?
+### I read the mailing-list from the Gmane news gateway. Can I post to the mailing-list?
 
->See previous FAQ.
+See previous FAQ.
 
-* I've been unsubscribed from one of the mailing-lists. What happened?
+### I've been unsubscribed from one of the mailing-lists. What happened?
 
->There are two possible reasons: If your account generates too many bounces you'll be automatically unsubscribed.  Please subscribe again with a more reliable account. If we receive even one _out of office notification_ from your vacation program,  your address will be unsubscribed and banned from our mailing-lists forever.  Sorry for that, there are just too many stupid people out there.
+There are two possible reasons: If your account generates too many bounces you'll be automatically unsubscribed.  Please subscribe again with a more reliable account. If we receive even one _out of office notification_ from your vacation program,  your address will be unsubscribed and banned from our mailing-lists forever.  Sorry for that, there are just too many stupid people out there.
 
-* How do I disable mail delivery from the mailing-list I'm subscribed to?
+### How do I disable mail delivery from the mailing-list I'm subscribed to?
 
->Suppose you are subscribed to clamav-users. Go to http://lists.clamav.net/cgi-bin/mailman/listinfo/clamav-users and enter your mail address at the bottom of the page. Click on __Unsubscribe or edit options__. At the next page enter your password and press _Log in_. Under _Your clamav-users Subscription Options_ choose _Disabled_ opposite _Mail delivery_ and press _Submit My Changes_ at the bottom of the page.
+Suppose you are subscribed to clamav-users. Go to http://lists.clamav.net/cgi-bin/mailman/listinfo/clamav-users and enter your mail address at the bottom of the page. Click on __Unsubscribe or edit options__. At the next page enter your password and press _Log in_. Under _Your clamav-users Subscription Options_ choose _Disabled_ opposite _Mail delivery_ and press _Submit My Changes_ at the bottom of the page.

--- a/faq/faq-overview.md
+++ b/faq/faq-overview.md
@@ -1,20 +1,44 @@
 # ClamAV Overview #
 
-## clamscan
+## `clamscan`
 
-command line scanner
+A command line program to scan files and directories that does not require the clamd daemon.
 
-## clamd
+## `clamd`
 
-multi threaded daemon
+A multi threaded daemon.
 
-## freshclam
+When `clamd` is running, use these tools to interact with it:
 
-cvd updating tool
+* `clamdtop`
 
-## libclamav
+  A command line GUI to monitor `clamd`.
 
-clamav library
+* `clamdscan`
 
-## sigtool
-cvd manipulation tool
+  A command line program to scan files and directories through `clamd`.
+
+## `freshclam`
+
+The signature database (cvd) update tool.
+
+## `libclamav`
+
+The clamav library - so you can build the ClamAV engine into your programs.
+
+## `sigtool`
+
+A signature database (cvd) manipulation tool - for malware analysts and signaure writers.
+
+## `clambc`
+
+Another signature manipulation tool specifically for bytecode signatures. 
+
+## `clamconf`
+
+A tool to check or generate ClamAV configuration files and collect additional information that may be needed to help remotely debug issues.
+
+## `clamav-config`
+
+An additional tool for checking how ClamAV was compiled.
+

--- a/faq/faq-pua.md
+++ b/faq/faq-pua.md
@@ -1,9 +1,9 @@
-#Potentially Unwanted Applications (PUA)
+# Potentially Unwanted Applications (PUA)
 
 ClamAV supports the detection of so called PUAs. At the moment the
 following categories are available:
 
-####Packed
+#### Packed
 
 This is a detection for files that use some kind of runtime packer. A
 runtime packer  can be used to reduce the size of executable files
@@ -12,14 +12,14 @@ considered malicious in general, runtime packers are widely used with
 malicious files since they can prevent a already known malware from
 detection by an Antivirus product.
 
-####PwTool
+#### PwTool
 
 Password tools are all applications that can be used to recover or
 decrypt passwords for various applications - like mail clients or
 system passwords. Such tools can be quite helpful if a password is
 lost, however, it can also be used to spy out passwords.
 
-####NetTool
+#### NetTool
 
 Applications that can be used to sniff, filter, manipulate or scan
 network traffic or networks.  While a networkscanner - for example -
@@ -27,29 +27,29 @@ can be a extremely helpful tool for admins, you may not want to see an
 average user playing around with it. Same goes for tools like netcat
 and the like.
 
-####P2P
+#### P2P
 
 Peer to Peer clients can be used to generate a lot of unwanted traffic
 and sometimes it happens that copyrights are violated by downloading
 copyright protected content (Music, Movies) - therefore we consider
 them possibly unwanted as well.
 
-####IRC
+#### IRC
 
 IRC Clients can be a productivity killer and depending on the client -
 a powerful platform for malicious scripts (take mIRC for example).
 
-####RAT
+#### RAT
 Remote Access Trojans are used to remotely access systems, but can be used also by system admins, for example VNC or RAdmin
 
-####Tool
+#### Tool
 General system tools, like process killers/finders
 
-####Spy
+#### Spy
 Keyloggers, spying tools
 
-####Server
+#### Server
 Server based badware like DistributedNet
 
-####Script
+#### Script
 Known "problem" scripts written in Javascript, ActiveX or similar.

--- a/faq/faq-safebrowsing.md
+++ b/faq/faq-safebrowsing.md
@@ -1,10 +1,10 @@
-# Safebrowsing  #
+# Safebrowsing
 
 __ClamAV 0.95__ introduced support for __Google Safe Browsing database__.
 The database is packed inside a CVD file and distributed through our mirror network. 
 This feature is disabled by default on all installations and should be enabled with extreme care.
 
-All signatures provided by Google Safe Browsing Database will be prefixed with the _Safebrowsing_ tag. If ClamAV reports <code>Safebrowsing.&lt;something&gt; FOUND</code>, it means that the advisory was provided by Google and not by ClamAV Virus database.
+All signatures provided by Google Safe Browsing Database will be prefixed with the _Safebrowsing_ tag. If ClamAV reports `Safebrowsing.&lt;something&gt; FOUND`, it means that the advisory was provided by Google and not by ClamAV Virus database.
 
 Please note that such reports DO NOT necessarily mean that the data scanned contains some malware. You should treat such data as a _potential_ risk, that is a _suspicious_ source of malware.
 

--- a/faq/faq-troubleshoot.md
+++ b/faq/faq-troubleshoot.md
@@ -1,63 +1,83 @@
-# Troubleshooting FAQ #
+# Troubleshooting FAQ
 
-* How many times per hour shall I run freshclam?
+### How many times per hour shall I run freshclam?
 
->If you are running ClamAV 0.7x please __upgrade now__.  
->
->If you are running ClamAV 0.8x or later, you can check for database update as often as 4 times per hour provided that you have the following options in freshclam.conf:   
-> __DNSDatabaseInfo__  
-> __current.cvd.clamav.net__   
-> __DatabaseMirror db.XY.clamav.net__   
-> __DatabaseMirror database.clamav.net__  
-> _Replace XY with your "country code":iana.  If you don't have that option, then you must stick with 1 check per hour._
+If you are running ClamAV 0.7x please __upgrade now__.  
 
-* I tried to submit a sample through the web interface, but it said the sample is already recognized by ClamAV. My clamscan tells me it's not. I have already updated my database and ClamAV engine, what's wrong with my setup?
+If you are running ClamAV 0.8x or later, you can check for database update as often as 4 times per hour provided that you have the following options in freshclam.conf:
 
->Please run clamscan with the <code>--detect-broken</code> option. Also  check that freshclam and clamscan are using the same path for storing/reading the database.
+```
+DNSDatabaseInfo  
+current.cvd.clamav.net   
+DatabaseMirror db.XY.clamav.net   
+DatabaseMirror database.clamav.net  
+```
 
-* I found an infected file in my HD/floppy/mailbox, but ClamAV doesn't recognize it yet. Can you help me? 
+_Replace XY with your "country code":iana.  If you don't have that option, then you must stick with 1 check per hour._
 
->Our virus database is kept up to date with the help of the community. Whenever you find a new virus which is not detected by ClamAV you should  "complete this form":submit. The virusdb team will review your submission and update the database if necessary. Before submitting a new sample: - check that the value of DatabaseDirectory, in both clamd.conf and freshclam.conf, is the same - update your database by running freshclam
+### I tried to submit a sample through the web interface, but it said the sample is already recognized by ClamAV. My clamscan tells me it's not. I have already updated my database and ClamAV engine, what's wrong with my setup?
 
-* How do I keep my virus database up to date?
+Please run clamscan with the `--detect-broken` option. Also  check that freshclam and clamscan are using the same path for storing/reading the database.
 
->ClamAV comes with _freshclam_, a tool which periodically checks for new database releases and keeps your database up to date.
+### I found an infected file in my HD/floppy/mailbox, but ClamAV doesn't recognize it yet. Can you help me? 
 
-* I get this error when running freshclam: _Invalid DNS reply. Falling back to HTTP mode_ or _ERROR: Can't query current.cvd.clamav.net_ . What does it mean?
+Our virus database is kept up to date with the help of the community. Whenever you find a new virus which is not detected by ClamAV you should  "complete this form":submit. The virusdb team will review your submission and update the database if necessary. Before submitting a new sample: - check that the value of DatabaseDirectory, in both clamd.conf and freshclam.conf, is the same - update your database by running freshclam
 
->There is a problem with your DNS server. Please check the entries in /etc/resolv.conf and verify that you can resolve the TXT record manually: <code>$ host -t txt current.cvd.clamav.net</code> If you can't, it means your network is broken. You'll be still able to download the updates, but you'll waste a lot of bandwidth checking for updates.
+### How do I keep my virus database up to date?
 
-* I get this error when running freshclam: _ERROR: Connection with ??? failed_ . What shall I do?
+ClamAV comes with _freshclam_, a tool which periodically checks for new database releases and keeps your database up to date.
 
->Either your dns servers are not working or you are blocking port 53/tcp. You should manually check that you can resolve hostnames with: <code>$ host database.clamav.net</code>. If it doesn't work, check your dns settings in /etc/resolv.conf. If it works, check that you can receive dns answers longer than 512 bytes, e.g. check that your firewall is not blocking packets which originate from port 53/tcp. An easy way to find it out is: <code>$ dig @ns1.clamav.net db.us.big.clamav.net</code>
+### I get this error when running freshclam: _Invalid DNS reply. Falling back to HTTP mode_ or _ERROR: Can't query current.cvd.clamav.net_ . What does it mean?
 
-* How do I know if my IP address has been blacklisted?
+There is a problem with your DNS server. Please check the entries in /etc/resolv.conf and verify that you can resolve the TXT record manually: `$ host -t txt current.cvd.clamav.net` If you can't, it means your network is broken. You'll be still able to download the updates, but you'll waste a lot of bandwidth checking for updates.
 
->Try to download daily.cvd with lynx or wget from the same machine that is running freshclam. Future versions of freshclam will provide a better way to deal with this.
+### I get this error when running freshclam: _ERROR: Connection with ??? failed_ . What shall I do?
 
-* What is the mirrors.dat file?
+Either your dns servers are not working or you are blocking port 53/tcp. You should manually check that you can resolve hostnames with: `$ host database.clamav.net`. If it doesn't work, check your dns settings in /etc/resolv.conf. If it works, check that you can receive dns answers longer than 512 bytes, e.g. check that your firewall is not blocking packets which originate from port 53/tcp. An easy way to find it out is: `$ dig @ns1.clamav.net db.us.big.clamav.net`
 
->mirrors.dat is used by freshclam to keep track of broken mirrors. It avoids the unnecessary delays caused by trying to download a CVD update from a mirror which failed multiple times during the last 24 hours.
+### How do I know if my IP address has been blacklisted?
 
-* I'm running ClamAV on a lot of clients on my local network. Can I serve the cvd files from a local server so that each client doesn't have to download them from your servers?
+Try to download daily.cvd with lynx or wget from the same machine that is running freshclam. Future versions of freshclam will provide a better way to deal with this.
 
->Sure, there are two possible solutions.
->
-> 1. If you want to take advantage of incremental updates, install a proxy server and then configure your freshclam clients to use it (watch for the HTTPProxyServer parameter in man freshclam.conf). 
->2. The second possible solution is to configure a local webserver on one of your machines (say machine1.mylan) and let freshclam download the \*.cvd files from http://database.clamav.net to the webserver's DocumentRoot. Finally, change freshclam.conf on your clients so that it reads:   `DatabaseMirror machine1.mylan`. First the database will be downloaded to the local webserver and then the other clients on the network will update their copy of the database from it. For this to work, you have to add `ScriptedUpdates off` on all of your machines!
+### What is the mirrors.dat file?
 
-* I can't wait for you to update the database! I need to use the new signature NOW!
+mirrors.dat is used by freshclam to keep track of broken mirrors. It avoids the unnecessary delays caused by trying to download a CVD update from a mirror which failed multiple times during the last 24 hours.
 
->No problem, save your own signatures in a text file with the appropriate extension (see "signatures.pdf":/doc/latest/signatures.pdf for more information). Put it in the same dir where the .cvd files are located. ClamAV will load it after the official .cvd files. You need not to sign the .db file.
+### I'm running ClamAV on a lot of clients on my local network. Can I serve the cvd files from a local server so that each client doesn't have to download them from your servers?
 
-* Can I download the virusdb manually?
+Sure, you can find more details on our [Mirror page].
 
->Yes, the virusdb can be downloaded from the _Latest releases_ section on our home page.
+1. If you want to take advantage of incremental updates, install a proxy server and then configure your freshclam clients to use it (watch for the HTTPProxyServer parameter in man freshclam.conf). 
 
-* I can't resolve current.cvd.clamav.net! Is there a problem with your/my DNS servers?
+2. The second possible solution is to:
 
->current.cvd.clamav.net has got only a TXT record, not a type A record! Try this command: `$ host -t txt current.cvd.clamav.net`. Please note that some not RFC compliant DNS servers (namely the one shipped with the Alcatel (now Thomson) SpeedTouch 510 modem) can't resolve TXT record. If that's the case, please recompile ClamAV with the flag `--enable-dns-fix` .
+  * Configure a local webserver on one of your machines (say machine1.mylan) 
+  
+  * Let freshclam download the \*.cvd files from http://database.clamav.net to the webserver's DocumentRoot. 
 
-* After ClamAV is installed, then what? How do I update / refresh the virus database?
+  * Finally, change freshclam.conf on your clients so that it includes:
+    
+    ```
+    DatabaseMirror machine1.mylan
+    ScriptedUpdates off
+    ```
+    
+    First the database will be downloaded to the local webserver and then the other clients on the network will update their copy of the database from it. 
+    
+    _Important_:  For this to work, you have to add `ScriptedUpdates off` on all of your machines!
 
-> You will need to edit the FreshClam.conf.example file located in /usr/local/etc. Once that is done, you will need to run a 'Sudo Freshclam' to download the signatures. You will need to run the command to update signatures often so that ClamAV has the most up to date signatures.
+### I can't wait for you to update the database! I need to use the new signature NOW!
+
+No problem, save your own signatures in a text file with the appropriate extension (see "signatures.pdf":/doc/latest/signatures.pdf for more information). Put it in the same dir where the .cvd files are located. ClamAV will load it after the official .cvd files. You need not to sign the .db file.
+
+### Can I download the virusdb manually?
+
+Yes, the virusdb can be downloaded from the _Latest releases_ section on our home page.
+
+### I can't resolve current.cvd.clamav.net! Is there a problem with your/my DNS servers?
+
+current.cvd.clamav.net has got only a TXT record, not a type A record! Try this command: `$ host -t txt current.cvd.clamav.net`. Please note that some not RFC compliant DNS servers (namely the one shipped with the Alcatel (now Thomson) SpeedTouch 510 modem) can't resolve TXT record. If that's the case, please recompile ClamAV with the flag `--enable-dns-fix`.
+
+### After ClamAV is installed, then what? How do I update / refresh the virus database?
+
+You will need to edit the freshclam.conf.example file located in /usr/local/etc. Once that is done, you will need to run a 'sudo sreshclam' to download the signatures. You will need to run the command to update signatures often so that ClamAV has the most up to date signatures.

--- a/faq/faq-uninstall.md
+++ b/faq/faq-uninstall.md
@@ -2,22 +2,60 @@
 
 ## If you installed from source
 
-* _./configure_
-* _sudo make uninstall_
+```bash
+./configure
+sudo make uninstall
+```
 
-##If you installed from packages
+## If you installed from packages
 
-* Debian: _dpkg --remove clamav*_
-* Redhat/Fedora: _yum remove clamav*_
-* Mandriva: _urpme clamav_
-* Gentoo: _emerge -C clamav_
-* FreeBSD?: _pkg_deinstall -f security/clamav*_
-* Slackware: _/etc/rc.d/rc.clamav stop; removepkg clamav_
+* Debian: 
 
-##Caveats
+  ```bash
+  dpkg --remove clamav*
+  ```
 
-Make sure that you haven’t got old libraries (_libclamav.so_) lying around your filesystem. You can verify it using: _$ ldd `which freshclam`_
+* Redhat/Fedora: 
+
+  ```bash
+  yum remove clamav*
+  ```
+
+* Mandriva: 
+
+  ```bash
+  urpme clamav
+  ```
+
+* Gentoo: 
+
+  ```bash
+  emerge -C clamav
+  ```
+
+* FreeBSD?: 
+
+  ```bash
+  pkg_deinstall -f security/clamav*
+  ```
+
+* Slackware: 
+
+  ```bash
+  /etc/rc.d/rc.clamav stop; removepkg clamav
+  ```
+
+## Caveats
+
+Make sure that you haven’t got old libraries (_libclamav.so_) lying around your filesystem. You can verify it using: _
+
+```bash
+$ ldd `which freshclam`
+```
+
 Also make sure there is really only one version of ClamAV installed on your system:
 
-* _$ whereis freshclam_
-* _$ whereis clamscan_
+```bash
+$ whereis freshclam
+$ whereis clamscan
+```

--- a/faq/faq-upgrade.md
+++ b/faq/faq-upgrade.md
@@ -1,15 +1,15 @@
 # Upgrading ClamAV #
 
-### ClamAV from Packages
+## ClamAV from Packages
 
 If you installed from a package, we suggest you find the approved package from your distro provider and install that. The ClamAV team does not maintain individual packages for every distribution build.
 If there are no new packages, you have three options:
 
 * Wait
-* Build Clam Package
-* Install From Source
+* Build ClamAV Package
+* Install ClamAV From Source
 
-### ClamAV from Sources
+## Install ClamAV From Source
 
 If you installed from sources, first uninstall the old version:
 
@@ -22,53 +22,69 @@ Depending on your installation method, you might want to backup configuration (l
 
 Backup your database signature (located in _/usr/local/share/clamav_ by default) before upgrading to newer ClamAV version. Restore the backed up database signature before running the updated version. This is to avoid getting the _/usr/local/share/clamav not locked_ error message when doing _freshclam_.
 
-### Webmin and yum
+## Webmin and yum
 
 To obtain a new version:
 
-`yum list clamav`
+```bash
+yum list clamav
+yum update clamav
+```
 
-`yum update clamav` (if everything updated properly, run freshclam)
+If everything updated properly, run freshclam to update your signature database.
 
-* What does _WARNING:	Current functionality level = 1, required = 2_ mean?
+### What does _WARNING:	Current functionality level = 1, required = 2_ mean?
 
 The _functionality level_ of the database determines which scanner engine version is required to use all of its signatures. If you don't upgrade immediately you will be missing the latest viruses.
 
-* What does _Your ClamAV installation is OUTDATED_ mean?
+### What does _Your ClamAV installation is OUTDATED_ mean?
 
 You'll get this message whenever a new version of ClamAV is released.  In order to detect all the latest viruses, it's not enough to keep your database up to date. You also need to run the latest version of the scanner. You can download the [sources] of the latest release from our website. If you are afraid to break something while upgrading, use  the [precompiled packages] for your operating system/distribution.  Remember: running the latest stable release also improves stability.
 
-* I upgraded to the latest stable version but I still get the message _Your ClamAV installation is OUTDATED_, why?
+### I upgraded to the latest stable version but I still get the message _Your ClamAV installation is OUTDATED_, why?
 
-Make sure there is really only one version of ClamAV installed on your system: 
-   `$ whereis freshclam` 
-   `$ whereis clamscan`
+Make sure there is really only one version of ClamAV installed on your system:
 
-Also make sure that you haven't got old libraries (`libclamav.so*`) lying around your filesystem. You can verify it using: `$ ldd $(which freshclam)`
+```bash
+$ whereis freshclam
+$ whereis clamscam
+```
 
-* What does _Malformed hexstring: This ClamAV version has reached End of Life_ mean?
+Also make sure that you haven't got old libraries (`libclamav.so*`) lying around your filesystem. You can verify it using: 
+
+```bash
+$ ldd $(which freshclam)
+```
+
+### What does _Malformed hexstring: This ClamAV version has reached End of Life_ mean?
 
 Please refer to: [eol-clamav]
 
-* How do I verify the integrity of ClamAV sources?
+### How do I verify the integrity of ClamAV sources?
 
 Using [GnuPG] you can easily verify the authenticity of your stable release downloads by using the following method: Download the [Talos PGP public key] from the VRT labs site. Import the key into your local public keyring: `$ gpg --import vrt.gpg`.  
  
-Download the stable release AND the corresponding `.sig` file to the same directory. Verify that the stable release download is signed with the [Talos PGP public key]: `$ gpg --verify clamav-X.XX.tar.gz.sig`  
+Download the stable release AND the corresponding `.sig` file to the same directory. Verify that the stable release download is signed with the [Talos PGP public key]: 
+
+```bash
+$ gpg --verify clamav-X.XX.tar.gz.sig
+```  
 
 Please note that the resulting output should look like the following:
 
-`gpg: Signature made Wed Jan 24 19:31:26 2018 EST`    
-`gpg:                using RSA key F13F9E16BCA5BFAD`    
-`gpg: Good signature from "Talos (Talos, Cisco Systems Inc.) <email address>" [unknown]`  
+```
+gpg: Signature made Wed Jan 24 19:31:26 2018 EST
+gpg:                using RSA key F13F9E16BCA5BFAD
+gpg: Good signature from "Talos (Talos, Cisco Systems Inc.) <email address>" [unknown]
+```  
 
 For other PGP implementation, please refer to their manual.
 
-* Where can I get the latest release, beta, or release candidate of ClamAV?
+### Where can I get the latest release, beta, or release candidate of ClamAV?
 
 Visit the [source download page].
 
-* Is my compiler/hardware/operating system supported by ClamAV?
+### Is my compiler/hardware/operating system supported by ClamAV?
 
 ClamAV supports a wide variety of compilers, hardware and operating systems. Our core compiler is gcc with Linux on 32 and 64 bit Intel platforms, though we also test using other compilers, including Sun's C compiler, Microsoft's Visual Studio, Intel's C compiler, LLVM/Clang, and others. To date we have only found one compiler that we do not support, GCC version 4.0.0 to 4.0.1 inclusive. We have found that version of the compiler produces incorrect code on all of the platforms and operating systems on which we have tested it. ClamAV will not work using that compiler and you MUST switch to an alternative, such as GCC3.4 or GCC4.1.   
 
@@ -78,7 +94,7 @@ Our configure scripts will detect if your compiler is affected by this bug and r
 
 
 [eol-clamav]: http://www.clamav.net/documents/end-of-life-policy-eol
-[GnuPG]:http://www.gnupg.org/
+[GnuPG]: http://www.gnupg.org/
 [sources]: https://github.com/Cisco-Talos/clamav-devel
 [Wiki]: https://github.com/Cisco-Talos/clamav-faq/blob/master/faq/Upgrading.md
 [precompiled packages]: http://www.clamav.net/download.html#otherversions 

--- a/faq/faq-whichversion.md
+++ b/faq/faq-whichversion.md
@@ -1,4 +1,4 @@
-# Which Version of ClamAV should I use? #
+# Which Version of ClamAV should I use?
 
 ## Stable
 

--- a/faq/faq-win32.md
+++ b/faq/faq-win32.md
@@ -1,41 +1,43 @@
-# Win32 FAQ #
+# Win32 FAQ
 
-* Why is ClamAV for Windows called Immunet now?
+### Why is ClamAV for Windows called Immunet now?
 
 Immunet now combines the power of ClamAV and our FireAMP products into one.
 
-* With the acquisition of Immunet by Sourcefire are both teams working together now or are they separate?
+### With the acquisition of Immunet, are both teams working together now or are they separate?
 
-Sourcefire has a single dedicated effort to deliver high quality Anti-Malware software.  We are pooling our resources between the ClamAV team and the former Immunet team to provide the best detection coverage and software for all OS’s and platforms we support.
+Cisco has a single dedicated effort to deliver high quality Anti-Malware software.  We are pooling our resources between the ClamAV team and the former Immunet team to provide the best detection coverage and software for all OS’s and platforms we support.
 
-* What is the difference between Immunet, ClamWin, and W32 Clam?
+### What is the difference between Immunet, ClamWin, and W32 Clam?
 
-Immunet is a real-time fully featured desktop AV solution.  It contains cloud based detection technologies and the enterprise grade ClamAV detection engine. The product is produced and maintained by Sourcefire which owns both ClamAV and Immunet.  
+Immunet is a real-time fully featured desktop AV solution.  It contains cloud based detection technologies and the enterprise grade ClamAV detection engine. The product is produced and maintained by Cisco which owns both ClamAV and Immunet.  
 W32 Clam was the original port of ClamAV to the Windows platform, this code is no longer maintained or needed, as ClamAV supports Windows.  
-ClamWin is a free application maintained by ClamWin Pty Ltd., and has no association with ClamAV, Sourcefire, or the Immunet product.  Additionally, ClamWin does not contain an on-access real-time scanner, and can only be used to manually scan files.
+ClamWin is a free application maintained by ClamWin Pty Ltd., and has no association with ClamAV, Cisco, or the Immunet product.  Additionally, ClamWin does not contain an on-access real-time scanner, and can only be used to manually scan files.
 
-* Is Immunet free for commercial use?
+### Is Immunet free for commercial use?
 
-Yup, Immunet is no longer free for commercial use. A [commercial version](http://www.cisco.com/c/en/us/products/security/fireamp-endpoints/index.html) named "AMP for Endpoints" is our commercial version.  If you are interested in deploying this in a commercial environment, we highly suggest checking that out.
+Immunet is not free for commercial use.  [AMP for Endpoints](http://www.cisco.com/c/en/us/products/security/fireamp-endpoints/index.html) is our product that replaced the commercial version.  If you are interested in deploying this in a commercial environment, we highly suggest checking that out.
 
-* Will Immunet send any sensitive data from my computer to the cloud?
+### Will Immunet send any sensitive data from my computer to the cloud?
 
 Immunet sends information about the files its scanning back to the cloud. This information is in the form of SHA hashes and file heuristics. Currently, this information is only collected for Windows PE files, or in other terms what most people refer to as executable files. No information is collected for other types of files, like Word, Excel, or PDF. Additionally, in some situations the entire PE file will be uploaded to the Cloud to determine if it is malicious. 
 For a complete overview please see the [privacy policy]
 
-* Are you going to make use of the Cloud in the \*nix version of ClamAV?
+### Are you going to make use of the Cloud in the \*nix version of ClamAV?
 
 The simple answer is “yes”.  The complex answer is “when”.  We are currently working on that roadmap and will keep everyone informed as that information becomes available.
 
-* Can I use Immunet with my current AV solution?
+### Can I use Immunet with my current AV solution?
 
 Yes. In fact it is encouraged.
 
-* Where should I report false positives or undetected malware?
+### Where should I report false positives or undetected malware?
 
-On ClamAV.net
+Please report __Undetected Malware__ [here](https://www.clamav.net/reports/malware).
 
-* Are there 64 bit versions of ClamAV for Windows as well as 32 bit?
+Please report __False Positives__ [here](https://www.clamav.net/reports/fp).
+
+### Are there 64 bit versions of ClamAV for Windows as well as 32 bit?
 
 Yes.  You can find both versions at [Clamav/downloads]
 


### PR DESCRIPTION
Pull request to clean up formatting.  Converted a lot of FAQ bullets to headers, and converted a lot of HTML \<code\>code\</code\> blocks to markdown code blocks. Eg:
\`code\` 
and
\```bash
code
\```
Some minor content improvements. 