### PR TITLE
Removes the 0.101 version number from the main page, and updates the …

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Additional:
 
 ---
 
-ClamAV User Manual © 2018 Cisco Systems, Inc.
+ClamAV User Manual 9 Cisco Systems, Inc.
 
 This document is distributed under the terms of the GNU General Public License v2.
 

--- a/faq/faq.md
+++ b/faq/faq.md
@@ -21,7 +21,7 @@ Table Of Contents
 
 ---
 
-ClamAV FAQ © 2018 Cisco Systems, Inc.
+ClamAV FAQ © 2019 Cisco Systems, Inc.
 
 This document is distributed under the terms of the GNU General Public License v2.
 

--- a/manual/UserManual.md
+++ b/manual/UserManual.md
@@ -1,4 +1,4 @@
-# Clam AntiVirus 0.101.0 *User Manual*
+# Clam AntiVirus *User Manual*
 
 ![image](/manual/UserManual/images/demon.png)
 
@@ -17,7 +17,7 @@ Table Of Contents
 
 ---
 
-ClamAV User Manual © 2018 Cisco Systems, Inc.
+ClamAV User Manual © 2019 Cisco Systems, Inc.
 
 This document is distributed under the terms of the GNU General Public License v2.
 


### PR DESCRIPTION
…copyright date on a couple pages.

As I understand it, the links on clamav.net are dynamically generated, so this link:
https://www.clamav.net/documents/clam-antivirus-0-101-0-user-manual

...should automatically change to this with this change:
https://www.clamav.net/documents/clam-antivirus-user-manual