### PR TITLE
Adds link to the new ClamAV Discord server

### DIFF
--- a/manual/UserManual/Introduction.md
+++ b/manual/UserManual/Introduction.md
@@ -151,6 +151,8 @@ Alternatively you can try asking on the `#clamav` IRC channel - launch your favo
     /join #clamav
 </pre>
 
+If you prefer Discord over IRC, join the [ClamAV Discord chat server](https://discord.gg/sGaxA5Q). The ClamAV Discord #general, and #irc-verbose channels are bridged with the #clamav IRC channel using a pair of bots to relay messages.
+
 ---
 
 ## Submitting New or Otherwise Undetected Malware


### PR DESCRIPTION
The new ClamAV Discord server is bridged with the #clamav IRC channel using relay bots.