### PR TITLE
Remove country code from DB update

### DIFF
--- a/faq/faq-cvd.md
+++ b/faq/faq-cvd.md
@@ -22,11 +22,7 @@ You can check for database update as often as 4 times per hour provided that you
 
 `DNSDatabaseInfo current.cvd.clamav.net`
 
-`DatabaseMirror db.XY.clamav.net`
-
 `DatabaseMirror database.clamav.net`
-
-Replace XY with your [country code].  If you don't have that option, then you must stick with 1 check per hour.
 
 ---
 


### PR DESCRIPTION
At some point in the past, it was required to add a country code URL (`DatabaseMirror db.XY.clamav.net`) to one's config to update more frequently than once per hour. Now that the mirror is behind cloudflare, this is no longer the case. This was already removed in one place in https://github.com/Cisco-Talos/clamav-faq/commit/17cfa358a5377306a8e99e6444be9f3c1afe141b#diff-b50dfd92f3abf2ac256a9e3fe5a253cc, but wasn't removed here. As far as I can tell, these two are the only two places it was referenced in the repo.