### PR TITLE
Remove references to AIX

### DIFF
--- a/faq/faq-misc.md
+++ b/faq/faq-misc.md
@@ -75,7 +75,7 @@ There are two solutions: Run `clamscan --debug`, look for _Deal with email numbe
 
 ## What platforms does it support?
 
-Clam AntiVirus works with Linux&reg;, Solaris, FreeBSD, OpenBSD, NetBSD, AIX, Mac OS X, Cygwin B20 on  multiple architectures such as Intel, Alpha, Sparc, Cobalt MIPS boxes, PowerPC, RISC 6000.
+Clam AntiVirus works with Linux&reg;, Solaris, FreeBSD, OpenBSD, NetBSD, Mac OS X, Cygwin B20 on  multiple architectures such as Intel, Alpha, Sparc, Cobalt MIPS boxes, PowerPC, RISC 6000.
 
 ---
 

--- a/manual/UserManual/Installation-Unix.md
+++ b/manual/UserManual/Installation-Unix.md
@@ -67,8 +67,6 @@ Certain versions on certain OSes will cause failures loading virus database:
 
 - CentOS 6 32bit: zlib 1.2.3-29
   - Solution: Update to newer version.
-- AIX 5.3: zlib 1.2.11-1
-  - Solution: Try different version, downgrade may be required.
 
 ---
 


### PR DESCRIPTION
We have no known AIX users.  One former user was unable to build
ClamAV on AIX.  Given that AIX is a paid product, we don't have the
means to test it and AIX is not officially supported.