### PR TITLE
Fix broken link to allow-list-database instructions

### DIFF
--- a/manual/UserManual/Signatures.md
+++ b/manual/UserManual/Signatures.md
@@ -93,7 +93,7 @@ ClamAV body-based signature content has a [special format](https://www.clamav.ne
 
 ### Other database files
 
-`*.fp` `*.sfp` `*.ign` `*.ign2`: [allowed files, ignored signatures](https://www.clamav.net/documents/Allow-list-databases)
+`*.fp` `*.sfp` `*.ign` `*.ign2`: [allowed files, ignored signatures](https://www.clamav.net/documents/allow-list-databases)
 
 `*.pwdb`: [Encrypted archive passwords](https://www.clamav.net/documents/passwords-for-archive-files-experimental)
 


### PR DESCRIPTION
It seems that the generated markdown URLs are case sensitive and the link used capital A instead of lowercase a, making the page fail to load (just goes to a white page).