### PR TITLE
Update the Private Mirror docs

### DIFF
--- a/faq/faq-cvd.md
+++ b/faq/faq-cvd.md
@@ -1,28 +1,14 @@
 # ClamAV Virus Database FAQ
 
-## What does _WARNING: DNS record is older than 3 hours_ mean?
+## How do I keep my virus database up to date?
 
-freshclam attempts to detect potential problems with DNS caches and  switches to the old mode if something looks suspicious. If this message appears seldomly, you can safely ignore it. If you get the error everytime you run freshclam, check your system clock. If it is set correctly, check your dns settings.  If those didn't help, try putting this at the top of your cronjob:
-
- `host -t txt current.cvd.clamav.net; perl -e 'printf "%d\n", time;' `
-
-The 4th field of the first line should be less than 3 &lowast; 3600 behind the output of the second line. If not, you have a caching DNS server somewhere  misbehaving.
+ClamAV comes with _FreshClam_, a tool which periodically checks for new database releases and keeps your database up to date.
 
 ---
 
 ## How often is the virus database updated?
 
-The virus database is usually updated many times per week. Sign up for our [VirusDB mailing list] to see our response times to new threats. The virusdb team tries to keep up with the latest threats in the wild.  You can contribute to make the virusdb updating process  more efficient by submitting samples of viruses via our "[Contact]" page on ClamAV.net.
-
----
-
-## How many times per hour shall I run freshclam?
-
-You can check for database update as often as 4 times per hour provided that you have the following options in `freshclam.conf`:
-
-`DNSDatabaseInfo current.cvd.clamav.net`
-
-`DatabaseMirror database.clamav.net`
+The virus database is usually updated once or twice per day. Sign up for our [VirusDB mailing list](https://lists.clamav.net/mailman/listinfo/clamav-virusdb) to see our response times to new threats. The virusdb team tries to keep up with the latest threats in the wild.  You can contribute to make the virusdb updating process  more efficient by submitting samples of viruses via our "[Contact](https://www.clamav.net/contact)" page on ClamAV.net.
 
 ---
 
@@ -38,71 +24,29 @@ Before publishing a CVD update, we test it for false positives using the latest 
 
 ---
 
-## I tried to submit a sample through the web interface, but it said the sample is already recognized by ClamAV. My clamscan tells me it's not. I have already updated my database and ClamAV engine, what's wrong with my setup?
+## I tried to submit a sample through the web interface, but it said the sample is already recognized by ClamAV. My ClamScan tells me it's not. I have already updated my database and ClamAV engine, what's wrong with my setup?
 
-Please run clamscan with the `--detect-broken` option. Also  check that freshclam and clamscan are using the same path for storing/reading the database.
-
----
-
-## I found an infected file in my HD/floppy/mailbox, but ClamAV doesn't recognize it yet. Can you help me?
-
-Our virus database is kept up to date with the help of the community. Whenever you find a new virus which is not detected by ClamAV you should [complete this form](submit). The virusdb team will review your submission and update the database if necessary. Before submitting a new sample: - check that the value of `DatabaseDirectory`, in both `clamd.conf` and `freshclam.conf`, is the same - update your database by running freshclam
+Please run ClamScan with the `--alert-broken` option. Also check that FreshClam and ClamScan are using the same path for storing/reading the database.
 
 ---
 
-## How do I keep my virus database up to date?
+## I found an infected file in my HD/USB/mailbox, but ClamAV doesn't recognize it yet. Can you help me?
 
-ClamAV comes with _freshclam_, a tool which periodically checks for new database releases and keeps your database up to date.
-
----
-
-## I get this error when running freshclam: _Invalid DNS reply. Falling back to HTTP mode_ or _ERROR: Can't query current.cvd.clamav.net_ . What does it mean?
-
-There is a problem with your DNS server. Please check the entries in /etc/resolv.conf and verify that you can resolve the TXT record manually:
-
-`$ host -t txt current.cvd.clamav.net`
-
-If you can't, it means your network is broken. You'll be still able to download the updates, but you'll waste a lot of bandwidth checking for updates.
-
----
-
-## I get this error when running freshclam: _ERROR: Connection with ??? failed_ . What shall I do?
-
-Either your dns servers are not working or you are blocking port 53/tcp. You should manually check that you can resolve hostnames with:
-
-`$ host database.clamav.net`
-
-If it doesn't work, check your dns settings in `/etc/resolv.conf`. If it works, check that you can receive dns answers longer than 512 bytes, e.g. check that your firewall is not blocking packets which originate from `port 53/tcp`.
-
-An easy way to find it out is:
-
-`$ dig @ns1.clamav.net db.us.big.clamav.net`
-
----
-
-## How do I know if my IP address has been blocked?
-
-Try to download daily.cvd with lynx or wget from the same machine that is running freshclam. Future versions of freshclam will provide a better way to deal with this.
-
----
-
-## What is the mirrors.dat file?
-
-mirrors.dat is used by freshclam to keep track of broken mirrors. It avoids the unnecessary delays caused by trying to download a CVD update from a mirror which failed multiple times during the last 24 hours.
+Our virus database is kept up to date with the help of the community. Whenever you find a new virus which is not detected by ClamAV you should [complete this form](https://www.clamav.net/reports/malware). The virusdb team will review your submission and update the database if necessary. Before submitting a new sample: - check that the value of `DatabaseDirectory`, in both `clamd.conf` and `freshclam.conf`, is the same - and update your database by running FreshClam to ensure you've scanned it with the latest virus database.
 
 ---
 
 ## I'm running ClamAV on a lot of clients on my local network. Can I serve the cvd files from a local server so that each client doesn't have to download them from your servers?
 
-Sure, you can find more details on our [Mirror page].
+Sure, you can find more details on our [Private Local Mirror page](https://www.clamav.net/documents/private-local-mirrors).
 
-1. If you want to take advantage of incremental updates, install a proxy server and then configure your freshclam clients to use it (watch for the HTTPProxyServer parameter in man freshclam.conf).
+1. If you want to take advantage of incremental updates, install a proxy server and then configure your FreshClam clients to use it (watch for the HTTPProxyServer parameter in `freshclam.conf`).
 
 2. The second possible solution is to:
 
   * Configure a local webserver on one of your machines (say `machine1.mylan`)
 
-  * Let freshclam download the `*.cvd` files from http://database.clamav.net to the webserver's *DocumentRoot*.
+  * Let FreshClam download the `*.cvd` files from [http://database.clamav.net](http://database.clamav.net) to the webserver's *DocumentRoot*.
 
   * Finally, change `freshclam.conf` on your clients so that it includes:
 
@@ -119,7 +63,7 @@ Sure, you can find more details on our [Mirror page].
 
 ## I can't wait for you to update the database! I need to use the new signature NOW!
 
-No problem, save your own signatures in a text file with the appropriate extension. Put it in the same dir where the .cvd files are located. ClamAV will load it after the official .cvd files. You need not to sign the .db file .
+No problem, save your own signatures in a text file with the appropriate extension (see [our signature writing documentation](https://www.clamav.net/documents/creating-signatures-for-clamav) for more information). Put the signature file in the same directory where the `.cvd` files are located. ClamAV will load it after the official `.cvd` files. You do not need to sign the `.db` file.
 
 ---
 
@@ -129,16 +73,14 @@ Yes, the virusdb can be downloaded from the _Latest releases_ section on our hom
 
 ---
 
-## I can't resolve current.cvd.clamav.net! Is there a problem with your/my DNS servers?
+## I can't resolve `current.cvd.clamav.net`! Is there a problem with your/my DNS servers?
 
-current.cvd.clamav.net has got only a TXT record, not a type A record! Try this command:
+`current.cvd.clamav.net` has got only a TXT record, not a type A record! Try this command:
 
 `$ host -t txt current.cvd.clamav.net`
 
-Please note that some not RFC compliant DNS servers (namely the one shipped with the *Alcatel* (now *Thomson*) **SpeedTouch 510 modem**) can't resolve `TXT` record. If that's the case, please recompile ClamAV with the flag   `--enable-dns-fix`.
+Please note that some not RFC compliant DNS servers (namely the one shipped with the *Alcatel* (now *Thomson*) **SpeedTouch 510 modem**) can't resolve `TXT` record. If that's the case, please recompile ClamAV with the flag `--enable-dns-fix` if using `./configure` or `-D ENABLE_FRESHCLAM_DNS_FIX=ON` if using CMake.
 
-[VirusDB mailing list]: https://lists.clamav.net/mailman/listinfo/clamav-virusdb
-[country code]: http://www.iana.org/domains/root/db
-[Mirror page]: http://www.clamav.net/doc/mirrors-private.html
-[Contact]: https://www.clamav.net/contact
-[submit]: https://www.clamav.net/reports/fp
+---
+
+For other questions regarding issues with Freshclam, see our [Freshclam Troubleshooting FAQ](https://www.clamav.net/documents/troubleshooting-faq).

--- a/faq/faq-troubleshoot.md
+++ b/faq/faq-troubleshoot.md
@@ -1,10 +1,14 @@
 # Troubleshooting FAQ
 
-## How many times per hour shall I run freshclam?
+## After ClamAV is installed, then what? How do I update / refresh the virus database?
 
-If you are running ClamAV 0.7x please __upgrade now__.
+You will need to edit the `freshclam.conf.example` file located in `/usr/local/etc`. Once that is done, you will need to run a `sudo freshclam` to download the signatures. You will need to run the command to update signatures often so that ClamAV has the most up to date signatures.
 
-If you are running ClamAV 0.8x or later, you can check for database update as often as 4 times per hour provided that you have the following options in `freshclam.conf`:
+---
+
+## How many times per hour shall I run FreshClam?
+
+You can check for database update as often as 4 times per hour provided that you have the following options in `freshclam.conf`:
 
 `DNSDatabaseInfo current.cvd.clamav.net`
 
@@ -12,27 +16,9 @@ If you are running ClamAV 0.8x or later, you can check for database update as of
 
 ---
 
-## I tried to submit a sample through the web interface, but it said the sample is already recognized by ClamAV. My clamscan tells me it's not. I have already updated my database and ClamAV engine, what's wrong with my setup?
+## I get this error when running FreshClam: _Invalid DNS reply. Falling back to HTTP mode_ or _ERROR: Can't query current.cvd.clamav.net_ . What does it mean?
 
-Please run clamscan with the `--detect-broken` option. Also  check that freshclam and clamscan are using the same path for storing/reading the database.
-
----
-
-## I found an infected file in my HD/floppy/mailbox, but ClamAV doesn't recognize it yet. How can I help?
-
-Our virus database is kept up to date with the help of the community. Whenever you find a new virus which is not detected by ClamAV you should [complete this form](https://www.clamav.net/reports/malware). The virusdb team will review your submission and update the database if necessary. Before submitting a new sample: - check that the value of DatabaseDirectory, in both clamd.conf and freshclam.conf, is the same - and update your database by running freshclam to ensure you've scanned it with the latest virus database.
-
----
-
-## How do I keep my virus database up to date?
-
-ClamAV comes with _freshclam_, a tool which periodically checks for new database releases and keeps your database up to date.
-
----
-
-## I get this error when running freshclam: _Invalid DNS reply. Falling back to HTTP mode_ or _ERROR: Can't query current.cvd.clamav.net_ . What does it mean?
-
-There is a problem with your DNS server. Please check the entries in `/etc/resolv.conf` and verify that you can resolve the TXT record manually:
+There is a problem with your DNS server. Please check the entries in /etc/resolv.conf and verify that you can resolve the TXT record manually:
 
 `$ host -t txt current.cvd.clamav.net`
 
@@ -40,13 +26,25 @@ If you can't, it means your network is broken. You'll be still able to download 
 
 ---
 
-## I get this error when running freshclam: _ERROR: Connection with ??? failed_ . What shall I do?
+## What does _WARNING: DNS record is older than 3 hours_ mean?
+
+Freshclam attempts to detect potential problems with DNS caches and switches to use HTTPS if something looks suspicious. If this message appears seldomly, you can safely ignore it. If you get the error everytime you run FreshClam, check your system clock. If it is set correctly, check your dns settings.  If those didn't help, try putting this at the top of your cronjob:
+
+ `host -t txt current.cvd.clamav.net; perl -e 'printf "%d\n", time;' `
+
+The 4th field of the first line should be less than 3 &lowast; 3600 behind the output of the second line. If not, you have a caching DNS server somewhere  misbehaving.
+
+---
+
+## I get this error when running FreshClam: _ERROR: Connection with ??? failed_ . What shall I do?
 
 Either your dns servers are not working or you are blocking port 53/tcp. You should manually check that you can resolve hostnames with:
 
 `$ host database.clamav.net`
 
-If it doesn't work, check your dns settings in `/etc/resolv.conf`. If it works, check that you can receive dns answers longer than 512 bytes, e.g. check that your firewall is not blocking packets which originate from port 53/tcp. An easy way to find it out is:
+If it doesn't work, check your dns settings in `/etc/resolv.conf`. If it works, check that you can receive dns answers longer than 512 bytes, e.g. check that your firewall is not blocking packets which originate from `port 53/tcp`.
+
+An easy way to find it out is:
 
 `$ dig @ns1.clamav.net db.us.big.clamav.net`
 
@@ -54,62 +52,10 @@ If it doesn't work, check your dns settings in `/etc/resolv.conf`. If it works, 
 
 ## How do I know if my IP address has been blocked?
 
-Try to download `daily.cvd` with *curl*, *wget*, or *lynx* from the same machine that is running *freshclam*. Future versions of freshclam will provide a better way to deal with this.
+Run FreshClam in verbose-mode (`-v`) to view the HTTP requests and responses. If you're seeing an HTTP 403 response, then you may have been blocked. If think you've been blocked, feel free to contact us for help getting un-blocked.
+
+If you're seeing an HTTP 429 response, then your IP may have been rate limited because it is downloading the same files from our CDN too frequently. If this happens to you, FreshClam will automatically work again after a cooldown timeout expires.
 
 ---
 
-## What is the mirrors.dat file?
-
-`mirrors.dat` is used by *freshclam* to keep track of broken mirrors. It avoids the unnecessary delays caused by trying to download a CVD update from a mirror which failed multiple times during the last 24 hours.
-
----
-
-## I'm running ClamAV on a lot of clients on my local network. Can I serve the cvd files from a local server so that each client doesn't have to download them from your servers?
-
-Sure, you can find more details on our [Private Local Mirror page](private-local-mirrors).
-
-1. If you want to take advantage of incremental updates, install a proxy server and then configure your freshclam clients to use it (watch for the HTTPProxyServer parameter in man freshclam.conf).
-
-2. The second possible solution is to:
-
-    * Configure a local webserver on one of your machines (say machine1.mylan)
-
-    * Let freshclam download the `*.cvd` files from [http://database.clamav.net](http://database.clamav.net) to the webserver's *DocumentRoot*.
-
-    * Finally, change freshclam.conf on your clients so that it includes:
-
-      `DatabaseMirror machine1.mylan`
-
-      `ScriptedUpdates off`
-
-      First the database will be downloaded to the local webserver and then the other clients on the network will update their copy of the database from it.
-
-      _Important_:  For this to work, you have to add `ScriptedUpdates off` on all of your machines!
-
----
-
-## I can't wait for you to update the database! I need to use the new signature NOW!
-
-No problem, save your own signatures in a text file with the appropriate extension (see [our signature writing documentation](https://www.clamav.net/documents/creating-signatures-for-clamav) for more information). Put the signature file in the same directory where the `.cvd` files are located. ClamAV will load it after the official `.cvd` files. You do not need to sign the `.db` file.
-
----
-
-## Can I download the virusdb manually?
-
-Yes, the virusdb can be downloaded from the _Latest releases_ section on our home page.
-
----
-
-## I can't resolve current.cvd.clamav.net! Is there a problem with your/my DNS servers?
-
-current.cvd.clamav.net has got only a TXT record, not a type A record! Try this command:
-
-`$ host -t txt current.cvd.clamav.net`
-
-Please note that some not RFC compliant DNS servers (namely the one shipped with the *Alcatel* (now *Thomson*) *SpeedTouch 510 modem*) can't resolve TXT record. If that's the case, please recompile ClamAV with the flag `--enable-dns-fix`.
-
----
-
-## After ClamAV is installed, then what? How do I update / refresh the virus database?
-
-You will need to edit the `freshclam.conf.example` file located in `/usr/local/etc`. Once that is done, you will need to run a `sudo freshclam` to download the signatures. You will need to run the command to update signatures often so that ClamAV has the most up to date signatures.
+For other questions regarding issues with the signature databases, see our [Virus Database FAQ](https://www.clamav.net/documents/clamav-virus-database-faq).

--- a/manual/UserManual/Introduction.md
+++ b/manual/UserManual/Introduction.md
@@ -153,7 +153,7 @@ Alternatively you can try asking on the `#clamav` IRC channel - launch your favo
     /join #clamav
 </pre>
 
-If you prefer Discord over IRC, join the [ClamAV Discord chat server](https://discord.gg/sGaxA5Q). The ClamAV Discord #general, and #irc-verbose channels are bridged with the #clamav IRC channel using a pair of bots to relay messages.
+If you prefer Discord over IRC, join the [ClamAV Discord chat server](https://discord.gg/6vNAqWnVgw). The ClamAV Discord #general, and #irc-verbose channels are bridged with the #clamav IRC channel using a pair of bots to relay messages.
 
 ---
 


### PR DESCRIPTION
The instructions for hosting a private mirror can no longer reference
wget or curl. Instead, the new "cvdupdate" tool is recommended for
keeping a private mirror up-to-date.

Also update the CVD and Freshclam Troubleshooting FAQs. These two had a
bunch of duplicate content, so removed the duplicate content and
attempted to sort them.

Also updated the URL for the Discord invite. The previous invite link
seemed to automatically remove users when they disconnect from Discord
unless they have an assigned role.  This new link should allow them to
automatically stay.